### PR TITLE
Add support for defining publish data ergonomically

### DIFF
--- a/btmesh-device/src/lib.rs
+++ b/btmesh-device/src/lib.rs
@@ -18,6 +18,7 @@ pub use btmesh_common::{
     ProductIdentifier, VersionIdentifier,
 };
 use btmesh_common::{IvIndex, ParseError, Ttl};
+use btmesh_models::foundation::configuration::model_publication::{PublishPeriod, Resolution};
 use btmesh_models::foundation::configuration::{AppKeyIndex, NetKeyIndex};
 pub use btmesh_models::Model;
 use core::future::Future;
@@ -64,6 +65,22 @@ pub enum PublicationCadence {
     None,
     OnChange,
     Periodic(Duration),
+}
+
+impl From<PublishPeriod> for PublicationCadence {
+    fn from(val: PublishPeriod) -> Self {
+        let steps = val.steps();
+        if steps == 0 {
+            PublicationCadence::OnChange
+        } else {
+            PublicationCadence::Periodic(match val.resolution() {
+                Resolution::Milliseconds100 => Duration::from_millis(steps as u64 * 100),
+                Resolution::Seconds1 => Duration::from_secs(steps as u64),
+                Resolution::Seconds10 => Duration::from_secs(steps as u64 * 10),
+                Resolution::Minutes10 => Duration::from_secs(steps as u64 * 60 * 10),
+            })
+        }
+    }
 }
 
 pub struct InboundMessage {

--- a/btmesh-driver/src/models/configuration/model_publication.rs
+++ b/btmesh-driver/src/models/configuration/model_publication.rs
@@ -1,6 +1,8 @@
 use crate::models::configuration::convert;
 use crate::{BackingStore, DriverError, Storage};
 use btmesh_device::{BluetoothMeshModelContext, InboundMetadata};
+use btmesh_models::foundation::configuration::model_publication::PublishPeriod;
+use btmesh_models::foundation::configuration::model_publication::PublishRetransmit;
 use btmesh_models::foundation::configuration::model_publication::{
     ModelPublicationMessage, ModelPublicationStatusMessage, PublicationDetails, PublishAddress,
 };
@@ -39,9 +41,8 @@ pub async fn dispatch<C: BluetoothMeshModelContext<ConfigurationServer>, B: Back
                         app_key_index: AppKeyIndex::new(0),
                         credential_flag: false,
                         publish_ttl: None,
-                        publish_period: 0,
-                        publish_retransmit_count: 0,
-                        publish_retransmit_interval_steps: 0,
+                        publish_period: PublishPeriod::from(0),
+                        publish_retransmit: PublishRetransmit::from(0),
                         model_identifier: get.model_identifier,
                     },
                 ),
@@ -53,27 +54,12 @@ pub async fn dispatch<C: BluetoothMeshModelContext<ConfigurationServer>, B: Back
                         app_key_index: AppKeyIndex::new(0),
                         credential_flag: false,
                         publish_ttl: None,
-                        publish_period: 0,
-                        publish_retransmit_count: 0,
-                        publish_retransmit_interval_steps: 0,
+                        publish_period: PublishPeriod::from(0),
+                        publish_retransmit: PublishRetransmit::from(0),
                         model_identifier: get.model_identifier,
                     },
                 ),
-                Ok(Some(publication)) => (
-                    (Status::Success, None),
-                    PublicationDetails {
-                        element_address: get.element_address,
-                        publish_address: publication.publish_address,
-                        app_key_index: publication.app_key_index,
-                        credential_flag: publication.credential_flag,
-                        publish_ttl: publication.publish_ttl,
-                        publish_period: publication.publish_period.into(),
-                        publish_retransmit_count: publication.publish_retransmit_count,
-                        publish_retransmit_interval_steps: publication
-                            .publish_retransmit_interval_steps,
-                        model_identifier: get.model_identifier,
-                    },
-                ),
+                Ok(Some(publication)) => ((Status::Success, None), publication.details),
             };
 
             info!("+++++ {} {} {}", status, err, details);

--- a/btmesh-driver/src/storage/provisioned/publications.rs
+++ b/btmesh-driver/src/storage/provisioned/publications.rs
@@ -1,12 +1,9 @@
 use crate::DriverError;
-use btmesh_common::{Composition, ModelIdentifier, Ttl};
-use btmesh_device::PublicationCadence;
+use btmesh_common::{Composition, ModelIdentifier};
 use btmesh_models::foundation::configuration::model_publication::{
     PublicationDetails, PublishAddress,
 };
-use btmesh_models::foundation::configuration::AppKeyIndex;
 use core::hash::Hash;
-use embassy_time::Duration;
 use heapless::Vec;
 
 #[cfg_attr(feature = "defmt", derive(::defmt::Format))]
@@ -35,9 +32,9 @@ impl<const N: usize> Publications<N> {
                     info!(
                         "  {} --> {} {}/{}",
                         model_descriptor.model_identifier,
-                        publication.publish_address,
-                        publication.publish_ttl,
-                        publication.publish_period
+                        publication.details.publish_address,
+                        publication.details.publish_ttl,
+                        publication.details.publish_period
                     );
                 }
             }
@@ -51,7 +48,8 @@ impl<const N: usize> Publications<N> {
     pub fn get(&self, element_index: u8, model_identifier: ModelIdentifier) -> Option<Publication> {
         self.entries.iter().find_map(|e| {
             if let Some(slot) = e {
-                if slot.element_index == element_index && slot.model_identifier == model_identifier
+                if slot.element_index == element_index
+                    && slot.details.model_identifier == model_identifier
                 {
                     Some(slot.clone())
                 } else {
@@ -73,7 +71,7 @@ impl<const N: usize> Publications<N> {
             for slot in self.entries.iter_mut().filter(|e| {
                 if let Some(slot) = e {
                     slot.element_index == element_index
-                        && slot.model_identifier == details.model_identifier
+                        && slot.details.model_identifier == details.model_identifier
                 } else {
                     false
                 }
@@ -86,21 +84,14 @@ impl<const N: usize> Publications<N> {
         if let Some(slot) = self.entries.iter_mut().find(|e| {
             if let Some(slot) = e {
                 slot.element_index == element_index
-                    && slot.model_identifier == details.model_identifier
+                    && slot.details.model_identifier == details.model_identifier
             } else {
                 false
             }
         }) {
             slot.replace(Publication {
                 element_index,
-                publish_address: details.publish_address,
-                app_key_index: details.app_key_index,
-                credential_flag: details.credential_flag,
-                publish_ttl: details.publish_ttl,
-                publish_period: details.publish_period.into(),
-                publish_retransmit_count: details.publish_retransmit_count,
-                publish_retransmit_interval_steps: details.publish_retransmit_interval_steps,
-                model_identifier: details.model_identifier,
+                details,
             });
             return Ok(());
         }
@@ -110,14 +101,7 @@ impl<const N: usize> Publications<N> {
             if let Some(slot) = self.entries.iter_mut().find(|e| matches!(e, None)) {
                 slot.replace(Publication {
                     element_index,
-                    publish_address: details.publish_address,
-                    app_key_index: details.app_key_index,
-                    credential_flag: details.credential_flag,
-                    publish_ttl: details.publish_ttl,
-                    publish_period: details.publish_period.into(),
-                    publish_retransmit_count: details.publish_retransmit_count,
-                    publish_retransmit_interval_steps: details.publish_retransmit_interval_steps,
-                    model_identifier: details.model_identifier,
+                    details,
                 });
                 Ok(())
             } else {
@@ -134,76 +118,5 @@ impl<const N: usize> Publications<N> {
 #[derive(Clone, Debug, Hash)]
 pub struct Publication {
     pub element_index: u8,
-    pub publish_address: PublishAddress,
-    pub app_key_index: AppKeyIndex,
-    pub credential_flag: bool,
-    pub publish_ttl: Option<Ttl>,
-    pub publish_period: PublishPeriod,
-    pub publish_retransmit_count: u8,
-    pub publish_retransmit_interval_steps: u8,
-    pub model_identifier: ModelIdentifier,
-}
-
-#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
-#[derive(Copy, Clone, Debug, Hash)]
-pub enum Resolution {
-    Milliseconds100,
-    Seconds1,
-    Seconds10,
-    Minutes10,
-}
-
-#[cfg_attr(feature = "defmt", derive(::defmt::Format))]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
-#[derive(Copy, Clone, Debug, Hash)]
-pub struct PublishPeriod {
-    period: u8,
-}
-
-impl PublishPeriod {
-    pub fn new(period: u8) -> Self {
-        Self { period }
-    }
-
-    pub fn resolution(&self) -> Resolution {
-        let resolution = self.period & 0b11;
-        match resolution {
-            0b00 => Resolution::Milliseconds100,
-            0b01 => Resolution::Seconds1,
-            0b10 => Resolution::Seconds10,
-            0b11 => Resolution::Minutes10,
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn steps(&self) -> u8 {
-        (self.period & 0b11111100) >> 2
-    }
-
-    pub fn cadence(&self) -> PublicationCadence {
-        let steps = self.steps();
-        if steps == 0 {
-            PublicationCadence::OnChange
-        } else {
-            PublicationCadence::Periodic(match self.resolution() {
-                Resolution::Milliseconds100 => Duration::from_millis(steps as u64 * 100),
-                Resolution::Seconds1 => Duration::from_secs(steps as u64),
-                Resolution::Seconds10 => Duration::from_secs(steps as u64 * 10),
-                Resolution::Minutes10 => Duration::from_secs(steps as u64 * 60 * 10),
-            })
-        }
-    }
-}
-
-impl From<PublishPeriod> for u8 {
-    fn from(val: PublishPeriod) -> Self {
-        val.period
-    }
-}
-
-impl From<u8> for PublishPeriod {
-    fn from(period: u8) -> Self {
-        Self { period }
-    }
+    pub details: PublicationDetails,
 }


### PR DESCRIPTION
Added some support for easier use of publish period and retransmit. Note that similar structs already exists in the project. 
I added these to use with bluer and didn't want to mess with the existing stuff until we are OK with this. Ideally we'd replace u8 fields with these structs in `PublicationDetails`

Next steps could be adding `From` implementations for embassy/std::Duration, but that's not critical.

I think there's a bug in how we encode retransmit packet, so I'll take a look at that next.