### PR TITLE
Update ProvisionedConfiguration display output

### DIFF
--- a/btmesh-driver/src/storage/provisioned/mod.rs
+++ b/btmesh-driver/src/storage/provisioned/mod.rs
@@ -61,9 +61,11 @@ impl ProvisionedConfiguration {
     }
 
     pub fn display(&self, composition: &Composition) {
-        info!("========================================================================");
-        info!("=  Provisioned                                                         =");
-        info!("------------------------------------------------------------------------");
+        info!(
+            " =====================================================================\n\
+            \t\t=  Provisioned                                                      =\n\
+            \t\t---------------------------------------------------------------------"
+        );
         info!("seq: {}", self.sequence);
         self.device_info.display();
         self.network_state.display();


### PR DESCRIPTION
This commit suggest changing the output when info logging is enabled.

The motivation for this is that the output currently looks like this:
```console
+ 163.603057 INFO  ========================================================================
+ └─ btmesh_driver::storage::provisioned::{impl#2}::display @ /home/danielbevenius/.cargo/git/checkouts/btmesh-e14acedbce757b27/cd4be51/btmesh-driver/src/fmt.rs:138
+ 163.603088 INFO  =  Provisioned                                                         =
+ └─ btmesh_driver::storage::provisioned::{impl#2}::display @ /home/danielbevenius/.cargo/git/checkouts/btmesh-e14acedbce757b27/cd4be51/btmesh-driver/src/fmt.rs:138
+ 163.603149 INFO  ------------------------------------------------------------------------
```
This commit suggest changing the code to just be a single call to the info function which will allow the output to be something like the following:
```console
0.343811 INFO   =====================================================================
		=  Provisioned                                                      =
		---------------------------------------------------------------------
└─ btmesh_driver::storage::provisioned::{impl#2}::display @ /home/danielbevenius/.cargo/git/checkouts/btmesh-e14acedbce757b27/cd4be51/btmesh-driver/src/fmt.rs:138
```