### PR TITLE
Add logging of number_of_elements to DeviceInfo

### DIFF
--- a/btmesh-driver/src/stack/provisioned/network/mod.rs
+++ b/btmesh-driver/src/stack/provisioned/network/mod.rs
@@ -31,6 +31,7 @@ pub struct DeviceInfo {
 impl DeviceInfo {
     pub fn display(&self) {
         info!("primary unicast address: {}", self.primary_unicast_address);
+        info!("number of elements: {}", self.number_of_elements);
     }
 
     pub fn new(primary_unicast_address: UnicastAddress, number_of_elements: u8) -> Self {


### PR DESCRIPTION
This commit adds info logging of the `number_of_elements` field for `DeviceInfo`.

The motivation for this that even though the number of elements can be seen when displaying the `Bindings` of a `ProvisionedConfiguration` it, at least for me, makes it a little clearer where these indices are coming from.