### PR TITLE
Add comment to crpl field in Composition

### DIFF
--- a/btmesh-common/src/lib.rs
+++ b/btmesh-common/src/lib.rs
@@ -487,7 +487,7 @@ pub struct Composition<X: Default = ()> {
     pub(crate) cid: CompanyIdentifier,
     pub(crate) pid: ProductIdentifier,
     pub(crate) vid: VersionIdentifier,
-    pub(crate) crpl: u16, // Count Reply Protection List
+    pub(crate) crpl: u16, // Count Replay Protection List
     pub(crate) features: Features,
     pub(crate) elements: Vec<ElementDescriptor<X>, 4>,
 }

--- a/btmesh-common/src/lib.rs
+++ b/btmesh-common/src/lib.rs
@@ -487,7 +487,7 @@ pub struct Composition<X: Default = ()> {
     pub(crate) cid: CompanyIdentifier,
     pub(crate) pid: ProductIdentifier,
     pub(crate) vid: VersionIdentifier,
-    pub(crate) crpl: u16,
+    pub(crate) crpl: u16, // Count Reply Protection List
     pub(crate) features: Features,
     pub(crate) elements: Vec<ElementDescriptor<X>, 4>,
 }


### PR DESCRIPTION
This commit adds a comment to the `crpl` field. This field represents the minimum number of replay protection list entries on a device.

The motivation for adding this is what it was not clear to me what the field `crpl` represented. I've looked in the Mesh Profile specification , and section 4.2.1 "Composition Data" contains a table with this field but does not explain the abbreviation. I'm only guessing here that it stands for `Count Replay Protection List`.