### PR TITLE
Remove unused imports in btmesh-device

### DIFF
--- a/btmesh-device/src/lib.rs
+++ b/btmesh-device/src/lib.rs
@@ -21,8 +21,6 @@ use btmesh_models::foundation::configuration::model_publication::{PublishPeriod,
 use btmesh_models::foundation::configuration::{AppKeyIndex, NetKeyIndex};
 pub use btmesh_models::Model;
 use core::future::Future;
-use core::pin::Pin;
-use core::task::{Context, Poll};
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 pub use embassy_sync::channel::{Channel, Receiver, Sender};
 use embassy_time::Duration;


### PR DESCRIPTION
Currently, the following warnings are genereated when building:
```console
Compiling btmesh-device v0.1.0 (/drogue/btmesh/btmesh-device) warning: unused import: `core::pin::Pin`
  --> btmesh-device/src/lib.rs:24:5
   |
24 | use core::pin::Pin;
   |     ^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `Context`, `Poll`
  --> btmesh-device/src/lib.rs:25:18
   |
25 | use core::task::{Context, Poll};
   |                  ^^^^^^^  ^^^
```
This commit removes the two unused imports.