### PR TITLE
Add allow unused_mut attribute for config variable

### DIFF
--- a/btmesh-nrf-softdevice/src/driver.rs
+++ b/btmesh-nrf-softdevice/src/driver.rs
@@ -13,6 +13,7 @@ use nrf_softdevice::{raw, Flash, Softdevice};
 
 #[allow(clippy::mut_from_ref)]
 fn enable_softdevice(device_name: &'static str) -> &'static mut Softdevice {
+    #[allow(unused_mut)]
     let mut config = nrf_softdevice::Config {
         clock: Some(raw::nrf_clock_lf_cfg_t {
             source: raw::NRF_CLOCK_LF_SRC_RC as u8,


### PR DESCRIPTION
Currently, when building with the following features a warning is generated:
```console
cargo b --features="defmt, nrf52840, relay" \
        --features="embassy-time/defmt-timestamp-uptime"

warning: variable does not need to be mutable
  --> src/driver.rs:16:9
   |
16 |     let mut config = nrf_softdevice::Config {
   |         ----^^^^^^
   |         |
   |         help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default

warning: `btmesh-nrf-softdevice` (lib) generated 1 warning
```
This commit adds an allow attribute to suppress this warning when these features are used.

The motivation for this is this warning shows up when building the firmware for the EclipseCon 2022 Hackaton (when building using local btmesh chechouts).