### PR TITLE
Run cargo fmt on btmesh-nrf-softdevice

### DIFF
--- a/btmesh-nrf-softdevice/src/driver.rs
+++ b/btmesh-nrf-softdevice/src/driver.rs
@@ -6,7 +6,9 @@ use btmesh_driver::interface::{
     AdvertisingAndGattNetworkInterfaces, AdvertisingOnlyNetworkInterfaces, NetworkInterfaces,
 };
 use btmesh_driver::storage::flash::FlashBackingStore;
-use btmesh_driver::{BluetoothMeshDriver, Driver as BaseDriver, BluetoothMeshDriverConfig, DriverError};
+use btmesh_driver::{
+    BluetoothMeshDriver, BluetoothMeshDriverConfig, Driver as BaseDriver, DriverError,
+};
 use core::future::{join, Future};
 use core::mem;
 use nrf_softdevice::{raw, Flash, Softdevice};
@@ -106,8 +108,12 @@ impl NrfSoftdeviceAdvertisingOnlyDriver {
     ) -> Self {
         let sd: &'static Softdevice = enable_softdevice(name);
         let rng = SoftdeviceRng::new(sd);
-        let backing_store =
-            FlashBackingStore::new(Flash::take(sd), base_address, extra_base_address, sequence_threshold);
+        let backing_store = FlashBackingStore::new(
+            Flash::take(sd),
+            base_address,
+            extra_base_address,
+            sequence_threshold,
+        );
         let adv_bearer = SoftdeviceAdvertisingBearer::new(sd);
 
         let network = AdvertisingOnlyNetworkInterfaces::new(adv_bearer);
@@ -161,8 +167,12 @@ impl NrfSoftdeviceAdvertisingAndGattDriver {
         let server = MeshGattServer::new(sd).unwrap();
 
         let rng = SoftdeviceRng::new(sd);
-        let backing_store =
-            FlashBackingStore::new(Flash::take(sd), base_address, extra_base_address, sequence_threshold);
+        let backing_store = FlashBackingStore::new(
+            Flash::take(sd),
+            base_address,
+            extra_base_address,
+            sequence_threshold,
+        );
         let adv_bearer = SoftdeviceAdvertisingBearer::new(sd);
 
         let gatt_bearer = SoftdeviceGattBearer::new(sd, server);

--- a/btmesh-nrf-softdevice/src/gatt.rs
+++ b/btmesh-nrf-softdevice/src/gatt.rs
@@ -1,12 +1,12 @@
 use atomic_polyfill::AtomicBool;
 use btmesh_bearer::{BearerError, GattBearer};
+use btmesh_device::Signal;
 use core::cell::RefCell;
 use core::future::Future;
 use core::sync::atomic::Ordering;
 use embassy_futures::select::select;
 use embassy_sync::blocking_mutex::raw::ThreadModeRawMutex;
 use embassy_sync::channel::Channel;
-use btmesh_device::Signal;
 use heapless::Vec;
 use nrf_softdevice::ble::peripheral::AdvertiseError;
 use nrf_softdevice::ble::{gatt_server, peripheral, Connection};


### PR DESCRIPTION
This crate is not part of the workspace which is why it was "missed" in Commit ffe1847fe6cfde100e5fd5a508c45fa56d12926a ("Cargo fmt updates").