### PR TITLE
Draft: version bumps in dependencies

### DIFF
--- a/btmesh-device/Cargo.toml
+++ b/btmesh-device/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 heapless = "0.7"
-btmesh-common = { path = "../btmesh-common"}
-btmesh-models = { path = "../btmesh-models"}
-embassy-sync = { version = "0.1.0", default-features = false }
+btmesh-common = { path = "../btmesh-common" }
+btmesh-models = { path = "../btmesh-models" }
+embassy-sync = { version = "0.2.0", default-features = false }
 embassy-time = { version = "0.1.0", default-features = false }
 embassy-futures = { version = "0.1.0", default-features = false }
 futures = { version = "0.3.21", default-features = false }
@@ -19,7 +19,4 @@ log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
 
 [features]
-defmt = [
-    "dep:defmt",
-    "heapless/defmt-impl",
-]
+defmt = ["dep:defmt", "heapless/defmt-impl"]

--- a/btmesh-driver/Cargo.toml
+++ b/btmesh-driver/Cargo.toml
@@ -10,10 +10,12 @@ btmesh-common = { path = "../btmesh-common" }
 btmesh-pdu = { path = "../btmesh-pdu" }
 btmesh-bearer = { path = "../btmesh-bearer" }
 btmesh-device = { path = "../btmesh-device" }
-btmesh-models = { path = "../btmesh-models", features = [ "serde" ] }
-btmesh-macro = { path = "../btmesh-macro"}
+btmesh-models = { path = "../btmesh-models", features = ["serde"] }
+btmesh-macro = { path = "../btmesh-macro" }
 embassy-time = { version = "0.1.0", default-features = false }
-embassy-sync = { version = "0.1.0", default-features = false, features = ["nightly"] }
+embassy-sync = { version = "0.2.0", default-features = false, features = [
+  "nightly",
+] }
 embassy-futures = { version = "0.1.0", default-features = false }
 heapless = "0.7"
 hash32 = "0.2.1"
@@ -26,53 +28,39 @@ p256 = { version = "0.10.0", default-features = false, features = ["ecdh"] }
 rand_core = { version = "0.6.2", default-features = false }
 embedded-storage-async = { version = "0.3.0", optional = true }
 embedded-storage = { version = "0.3.0", optional = true }
-postcard = { version = "1.0.1", default-features = false, features = ["heapless"], optional = true }
+postcard = { version = "1.0.1", default-features = false, features = [
+  "heapless",
+], optional = true }
 defmt = { version = "0.3", optional = true }
 
 [dev-dependencies]
-rand_core = { version = "0.6.2", default-features = false, features = ["getrandom"] }
+rand_core = { version = "0.6.2", default-features = false, features = [
+  "getrandom",
+] }
 
 [features]
-default = [
-    "flash",
-    "memory",
-    "relay",
-    "std",
-]
-std = [
-    "embassy-time/std"
-]
+default = ["flash", "memory", "relay", "std"]
+std = ["embassy-time/std"]
 flash = [
-    "embedded-storage",
-    "embedded-storage-async",
-    "postcard",
-    "postcard/use-defmt",
-    "serde/derive",
-    "btmesh-common/serde",
-    "btmesh-pdu/serde"
+  "embedded-storage",
+  "embedded-storage-async",
+  "postcard",
+  "postcard/use-defmt",
+  "serde/derive",
+  "btmesh-common/serde",
+  "btmesh-pdu/serde",
 ]
-memory = [
-
-]
+memory = []
 defmt = [
-    "dep:defmt",
-    "btmesh-common/defmt",
-    "btmesh-bearer/defmt",
-    "btmesh-device/defmt",
-    "btmesh-models/defmt",
-    "btmesh-pdu/defmt",
+  "dep:defmt",
+  "btmesh-common/defmt",
+  "btmesh-bearer/defmt",
+  "btmesh-device/defmt",
+  "btmesh-models/defmt",
+  "btmesh-pdu/defmt",
 ]
 
-relay = [
-    "btmesh-common/relay",
-    "btmesh-models/relay",
-]
-proxy = [
-    "btmesh-common/proxy",
-]
-friend = [
-    "btmesh-common/friend",
-]
-low_power = [
-    "btmesh-common/low_power",
-]
+relay = ["btmesh-common/relay", "btmesh-models/relay"]
+proxy = ["btmesh-common/proxy"]
+friend = ["btmesh-common/friend"]
+low_power = ["btmesh-common/low_power"]

--- a/btmesh-driver/Cargo.toml
+++ b/btmesh-driver/Cargo.toml
@@ -26,7 +26,7 @@ cmac = { version = "0.6.0", default-features = false }
 aes = { version = "0.7", default-features = false }
 p256 = { version = "0.10.0", default-features = false, features = ["ecdh"] }
 rand_core = { version = "0.6.2", default-features = false }
-embedded-storage-async = { version = "0.3.0", optional = true }
+embedded-storage-async = { version = "0.4.0", optional = true }
 embedded-storage = { version = "0.3.0", optional = true }
 postcard = { version = "1.0.1", default-features = false, features = [
   "heapless",

--- a/btmesh-driver/Cargo.toml
+++ b/btmesh-driver/Cargo.toml
@@ -16,6 +16,7 @@ embassy-time = { version = "0.1.0", default-features = false }
 embassy-sync = { version = "0.2.0", default-features = false, features = [
   "nightly",
 ] }
+critical-section = { version = "1.1.1", default-features = false, optional = true }
 embassy-futures = { version = "0.1.0", default-features = false }
 heapless = "0.7"
 hash32 = "0.2.1"
@@ -40,7 +41,7 @@ rand_core = { version = "0.6.2", default-features = false, features = [
 
 [features]
 default = ["flash", "memory", "relay", "std"]
-std = ["embassy-time/std"]
+std = ["embassy-time/std", "critical-section/std"]
 flash = [
   "embedded-storage",
   "embedded-storage-async",

--- a/btmesh-driver/src/lib.rs
+++ b/btmesh-driver/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(dead_code)]
 #![allow(clippy::await_holding_refcell_ref)]
 #![feature(async_closure)]
+#![feature(impl_trait_in_assoc_type)]
 
 use btmesh_bearer::beacon::Beacon;
 use btmesh_common::address::{Address, UnicastAddress};

--- a/btmesh-driver/src/storage/flash.rs
+++ b/btmesh-driver/src/storage/flash.rs
@@ -2,7 +2,7 @@ use crate::storage::{BackingStore, StorageError};
 use crate::util::hash::hash_of;
 use crate::ProvisionedConfiguration;
 use core::future::Future;
-use embedded_storage_async::nor_flash::AsyncNorFlash;
+use embedded_storage_async::nor_flash::NorFlash;
 use postcard::{from_bytes, to_slice};
 
 #[repr(align(4))]
@@ -14,7 +14,7 @@ pub enum LatestLoad {
     Provisioned { hash: u64, sequence: u32 },
 }
 
-pub struct FlashBackingStore<F: AsyncNorFlash, const PAGE_SIZE: u32 = 4096> {
+pub struct FlashBackingStore<F: NorFlash, const PAGE_SIZE: u32 = 4096> {
     flash: F,
     base_address: u32,
     extra_base_address: Option<u32>,
@@ -23,7 +23,7 @@ pub struct FlashBackingStore<F: AsyncNorFlash, const PAGE_SIZE: u32 = 4096> {
     buffer: AlignedBuffer<USEFUL_BUFFER_SIZE>,
 }
 
-impl<F: AsyncNorFlash, const PAGE_SIZE: u32> FlashBackingStore<F, PAGE_SIZE> {
+impl<F: NorFlash, const PAGE_SIZE: u32> FlashBackingStore<F, PAGE_SIZE> {
     pub fn new(
         flash: F,
         base_address: u32,
@@ -77,7 +77,7 @@ impl<F: AsyncNorFlash, const PAGE_SIZE: u32> FlashBackingStore<F, PAGE_SIZE> {
 
 const USEFUL_BUFFER_SIZE: usize = 2048;
 
-impl<F: AsyncNorFlash, const PAGE_SIZE: u32> BackingStore for FlashBackingStore<F, PAGE_SIZE> {
+impl<F: NorFlash, const PAGE_SIZE: u32> BackingStore for FlashBackingStore<F, PAGE_SIZE> {
     type LoadFuture<'m> =  impl Future<Output = Result<ProvisionedConfiguration, StorageError>> + 'm
         where
             Self: 'm;

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -24,6 +24,7 @@ embassy-sync = { version = "0.2.0", default-features = false, features = [
 ] }
 embassy-futures = { version = "0.1.0", default-features = false }
 nrf-softdevice = { version = "0.1.0", default-features = false, features = [
+  "nightly",
   "ble-peripheral",
   "ble-gatt-server",
 ] }

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -12,64 +12,61 @@ edition = "2021"
 btmesh-common = { path = "../btmesh-common", default-features = false }
 btmesh-pdu = { path = "../btmesh-pdu", default-features = false }
 btmesh-bearer = { path = "../btmesh-bearer", default-features = false }
-btmesh-driver = { path = "../btmesh-driver", default-features = false, features = [ "flash" ] }
+btmesh-driver = { path = "../btmesh-driver", default-features = false, features = [
+  "flash",
+] }
 btmesh-device = { path = "../btmesh-device", default-features = false }
 heapless = "0.7"
 atomic-polyfill = { version = "1", default-features = false }
 rand_core = { version = "0.6.2", default-features = false }
-embassy-sync = { version = "0.1.0", default-features = false, features = ["nightly" ] }
+embassy-sync = { version = "0.2.0", default-features = false, features = [
+  "nightly",
+] }
 embassy-futures = { version = "0.1.0", default-features = false }
-nrf-softdevice = { version = "0.1.0", default-features = false, features = ["ble-peripheral", "ble-gatt-server"] }
-nrf-softdevice-s140 = { version = "0.1.0", optional=true }
+nrf-softdevice = { version = "0.1.0", default-features = false, features = [
+  "ble-peripheral",
+  "ble-gatt-server",
+] }
+nrf-softdevice-s140 = { version = "0.1.0", optional = true }
 nrf-softdevice-macro = { version = "0.1.0" }
 defmt = { version = "0.3", optional = true }
-embassy-nrf = { version = "0.1.0", default-features = false, features = ["time-driver-rtc1", "gpiote"], optional = true }
+embassy-nrf = { version = "0.1.0", default-features = false, features = [
+  "time-driver-rtc1",
+  "gpiote",
+], optional = true }
 embassy-time = { version = "0.1.0", default-features = false }
 
 [features]
-default = [
-    "nrf52840"
-]
+default = ["nrf52840"]
 
 nrf52840 = [
-    "embassy-nrf/nrf52840",
-    "nrf-softdevice/nrf52840",
-    "nrf-softdevice/ble-central",
-    "nrf-softdevice/s140",
-    "nrf-softdevice-s140",
+  "embassy-nrf/nrf52840",
+  "nrf-softdevice/nrf52840",
+  "nrf-softdevice/ble-central",
+  "nrf-softdevice/s140",
+  "nrf-softdevice-s140",
 ]
 
 nrf52833 = [
-    "embassy-nrf/nrf52833",
-    "nrf-softdevice/nrf52833",
-    "nrf-softdevice/ble-central",
-    "nrf-softdevice/s140",
-    "nrf-softdevice-s140",
+  "embassy-nrf/nrf52833",
+  "nrf-softdevice/nrf52833",
+  "nrf-softdevice/ble-central",
+  "nrf-softdevice/s140",
+  "nrf-softdevice-s140",
 ]
 
 defmt = [
-    "dep:defmt",
-    "btmesh-driver/defmt",
-#    "nrf-softdevice/defmt",
+  "dep:defmt",
+  "btmesh-driver/defmt",
+  #    "nrf-softdevice/defmt",
 ]
 
-gatt = [
-]
+gatt = []
 
-relay = [
-    "btmesh-common/relay",
-    "btmesh-driver/relay",
-]
-proxy = [
-    "btmesh-common/proxy",
-    "gatt",
-]
-friend = [
-    "btmesh-common/friend"
-]
-low_power = [
-    "btmesh-common/low_power"
-]
+relay = ["btmesh-common/relay", "btmesh-driver/relay"]
+proxy = ["btmesh-common/proxy", "gatt"]
+friend = ["btmesh-common/friend"]
+low_power = ["btmesh-common/low_power"]
 
 [patch.crates-io]
 embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-executor-v0.1.1" }

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -70,7 +70,7 @@ friend = ["btmesh-common/friend"]
 low_power = ["btmesh-common/low_power"]
 
 [patch.crates-io]
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -69,7 +69,7 @@ friend = ["btmesh-common/friend"]
 low_power = ["btmesh-common/low_power"]
 
 [patch.crates-io]
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-executor-v0.1.1" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
-nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
-nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -81,11 +81,11 @@ opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -27,6 +27,7 @@ embassy-time = { version = "0.1.0", default-features = false, features = [
   "defmt-timestamp-uptime",
 ] }
 embassy-nrf = { version = "0.1.0", default-features = false, features = [
+  "rt",
   "nrf52833",
   "gpiote",
   "time-driver-rtc1",

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-    "Bob McWhirter <bmcwhirt@redhat.com>"
+  "Ulf Lilleengen <lulf@redhat.com>",
+  "Bob McWhirter <bmcwhirt@redhat.com>",
 ]
 edition = "2018"
 name = "basic"
 version = "0.1.0"
 description = "microbit Bluetooth Mesh example"
-keywords = ["ble", "bluetooth", "mesh", "nrf", "nrf52" ]
+keywords = ["ble", "bluetooth", "mesh", "nrf", "nrf52"]
 resolver = "2"
 
 [workspace]
@@ -17,18 +17,34 @@ defmt = { version = "0.3" }
 defmt-rtt = { version = "0.3" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-embassy-executor = { version = "0.1.1", default-features = false, features = [ "defmt", "nightly", "integrated-timers" ] }
-embassy-time = { version = "0.1.0", default-features = false, features = [ "defmt", "defmt-timestamp-uptime" ] }
-embassy-nrf = { version = "0.1.0", default-features = false, features = ["nrf52833", "gpiote", "time-driver-rtc1"]}
+embassy-executor = { version = "0.1.1", default-features = false, features = [
+  "defmt",
+  "nightly",
+  "integrated-timers",
+] }
+embassy-time = { version = "0.1.0", default-features = false, features = [
+  "defmt",
+  "defmt-timestamp-uptime",
+] }
+embassy-nrf = { version = "0.1.0", default-features = false, features = [
+  "nrf52833",
+  "gpiote",
+  "time-driver-rtc1",
+] }
 embassy-futures = { version = "0.1.0", default-features = false }
 
 
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
-btmesh-models = { path = "../../../../btmesh-models"}
-btmesh-device = { path = "../../../../btmesh-device"}
-btmesh-macro = { path = "../../../../btmesh-macro"}
-btmesh-nrf-softdevice = { path = "../../../", default-features = false, features = ["defmt", "nrf52833", "proxy", "relay"] }
+btmesh-models = { path = "../../../../btmesh-models" }
+btmesh-device = { path = "../../../../btmesh-device" }
+btmesh-macro = { path = "../../../../btmesh-macro" }
+btmesh-nrf-softdevice = { path = "../../../", default-features = false, features = [
+  "defmt",
+  "nrf52833",
+  "proxy",
+  "relay",
+] }
 
 [features]
 
@@ -61,7 +77,7 @@ overflow-checks = false
 codegen-units = 8
 debug = 0
 debug-assertions = false
-opt-level = 1 
+opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -81,14 +81,14 @@ opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-executor-v0.1.1" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
-nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
-nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 
 #nrf-softdevice = { path = "../../../../../nrf-softdevice/nrf-softdevice" }
 #nrf-softdevice-s140 = { path = "../../../../../nrf-softdevice/nrf-softdevice-s140" }

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -81,11 +81,11 @@ opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-executor-v0.1.1" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", tag = "embassy-time-v0.1.0" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
-nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
-nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "e8ee783fdd9674a061c2479d0a29e87e4e2a6d2f" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -27,6 +27,7 @@ embassy-time = { version = "0.1.0", default-features = false, features = [
   "defmt-timestamp-uptime",
 ] }
 embassy-nrf = { version = "0.1.0", default-features = false, features = [
+  "rt",
   "nrf52840",
   "gpiote",
   "time-driver-rtc1",

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -81,11 +81,11 @@ opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "37a1e9f971214c11a614b06b230be27c688fff1d" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
 nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 authors = [
-    "Ulf Lilleengen <lulf@redhat.com>",
-    "Bob McWhirter <bmcwhirt@redhat.com>"
+  "Ulf Lilleengen <lulf@redhat.com>",
+  "Bob McWhirter <bmcwhirt@redhat.com>",
 ]
 edition = "2018"
 name = "basic"
 version = "0.1.0"
 description = "nrf52840-dk Bluetooth Mesh example"
-keywords = ["ble", "bluetooth", "mesh", "nrf", "nrf52" ]
+keywords = ["ble", "bluetooth", "mesh", "nrf", "nrf52"]
 resolver = "2"
 
 [workspace]
@@ -17,18 +17,34 @@ defmt = { version = "0.3" }
 defmt-rtt = { version = "0.3" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-embassy-executor = { version = "0.1.1", default-features = false, features = [ "defmt", "nightly", "integrated-timers" ] }
-embassy-time = { version = "0.1.0", default-features = false, features = [ "defmt", "defmt-timestamp-uptime" ] }
-embassy-nrf = { version = "0.1.0", default-features = false, features = ["nrf52840", "gpiote", "time-driver-rtc1"]}
+embassy-executor = { version = "0.1.1", default-features = false, features = [
+  "defmt",
+  "nightly",
+  "integrated-timers",
+] }
+embassy-time = { version = "0.1.0", default-features = false, features = [
+  "defmt",
+  "defmt-timestamp-uptime",
+] }
+embassy-nrf = { version = "0.1.0", default-features = false, features = [
+  "nrf52840",
+  "gpiote",
+  "time-driver-rtc1",
+] }
 embassy-futures = { version = "0.1.0", default-features = false }
 
 
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
-btmesh-models = { path = "../../../../btmesh-models"}
-btmesh-device = { path = "../../../../btmesh-device"}
-btmesh-macro = { path = "../../../../btmesh-macro"}
-btmesh-nrf-softdevice = { path = "../../../", features = ["defmt", "nrf52840", "proxy", "relay"] }
+btmesh-models = { path = "../../../../btmesh-models" }
+btmesh-device = { path = "../../../../btmesh-device" }
+btmesh-macro = { path = "../../../../btmesh-macro" }
+btmesh-nrf-softdevice = { path = "../../../", features = [
+  "defmt",
+  "nrf52840",
+  "proxy",
+  "relay",
+] }
 
 [features]
 
@@ -61,7 +77,7 @@ overflow-checks = false
 codegen-units = 8
 debug = 0
 debug-assertions = false
-opt-level = 1 
+opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]

--- a/btmesh-nrf-softdevice/src/gatt.rs
+++ b/btmesh-nrf-softdevice/src/gatt.rs
@@ -87,7 +87,6 @@ impl SoftdeviceGattBearer {
                     },
                 )
                 .await
-                .ok()
             };
 
             let reset_fut = RESET_SIGNAL.wait();

--- a/btmesh-nrf-softdevice/src/gatt.rs
+++ b/btmesh-nrf-softdevice/src/gatt.rs
@@ -139,7 +139,7 @@ impl GattBearer<66> for SoftdeviceGattBearer {
                     Some(ConnectionChannel::Proxy) => {
                         self.server
                             .proxy
-                            .data_out_notify(connection, pdu.clone())
+                            .data_out_notify(connection, &pdu)
                             .map_err(|_| BearerError::TransmissionFailure)?;
                     }
                     _ => {}

--- a/btmesh-nrf-softdevice/src/lib.rs
+++ b/btmesh-nrf-softdevice/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(associated_type_defaults)]
 #![feature(future_join)]
 #![allow(dead_code)]
+#![feature(impl_trait_in_assoc_type)]
 
 #[cfg(not(any(feature = "nrf52833", feature = "nrf52840",)))]
 compile_error!("No chip feature activated. You must activate exactly one of the following features: nrf52833, nrf52840");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2022-11-22"
-components = [ "rust-src", "rustfmt" ]
-targets = [ "thumbv7em-none-eabi", "thumbv7em-none-eabihf" ]
+channel = "nightly-2023-06-20"
+components = ["rust-src", "rustfmt"]
+targets = ["thumbv7em-none-eabi", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
Hello,

I wanted to bring to your attention some compilation issues that I encountered while trying to start a new Bluetooth Mesh project based on the [drogue-device](https://github.com/drogue-iot/drogue-device/tree/main/examples/nrf52/microbit/bt-mesh) repository. Specifically, I ran into issues related to dependencies updates, including `embassy-sync`, `embassy-nrf`, `nrf-softdevice`, and `embedded-storage-async`. Additionally, some of these issues were also related to recent Rust nightlies, specifically TAIT for async traits.

I have created a draft pull request to address these issues, and I would be happy to make any necessary changes that you may suggest. 

Note: one of the commits (105a07685923723b4e837fce8ac9edcd937d6764) contains numerous modifications related to formatting.

Thank you for your time working on this project!