### PR TITLE
Fix compatibility issue with Android nRF Mesh

### DIFF
--- a/btmesh-common/Cargo.toml
+++ b/btmesh-common/Cargo.toml
@@ -17,20 +17,19 @@ uuid = { version = "1.2.2", default-features = false }
 #logging
 log = { version = "0.4", optional = true }
 defmt = { version = "0.3", optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, features = [
+  "derive",
+], optional = true }
 darling = { version = "0.14.1", optional = true }
-syn = { version = "1.0.89", default-features = false, features = ["full", "extra-traits"], optional = true }
+syn = { version = "1.0.89", default-features = false, features = [
+  "full",
+  "extra-traits",
+], optional = true }
 
 
 [features]
-darling = [
-    "dep:darling",
-    "dep:syn",
-]
-defmt = [
-    "dep:defmt",
-    "heapless/defmt-impl",
-]
+darling = ["dep:darling", "dep:syn"]
+defmt = ["dep:defmt", "heapless/defmt-impl"]
 relay = []
 proxy = []
 friend = []

--- a/btmesh-device/Cargo.toml
+++ b/btmesh-device/Cargo.toml
@@ -10,7 +10,7 @@ heapless = "0.7"
 btmesh-common = { path = "../btmesh-common" }
 btmesh-models = { path = "../btmesh-models" }
 embassy-sync = { version = "0.2.0", default-features = false }
-embassy-time = { version = "0.1.0", default-features = false }
+embassy-time = { version = "0.1.3", default-features = false }
 embassy-futures = { version = "0.1.0", default-features = false }
 futures = { version = "0.3.21", default-features = false }
 

--- a/btmesh-device/Cargo.toml
+++ b/btmesh-device/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 heapless = "0.7"
 btmesh-common = { path = "../btmesh-common" }
 btmesh-models = { path = "../btmesh-models" }
-embassy-sync = { version = "0.2.0", default-features = false }
+embassy-sync = { version = "0.3.0", default-features = false }
 embassy-time = { version = "0.1.3", default-features = false }
 embassy-futures = { version = "0.1.0", default-features = false }
 futures = { version = "0.3.21", default-features = false }

--- a/btmesh-driver/Cargo.toml
+++ b/btmesh-driver/Cargo.toml
@@ -12,7 +12,7 @@ btmesh-bearer = { path = "../btmesh-bearer" }
 btmesh-device = { path = "../btmesh-device" }
 btmesh-models = { path = "../btmesh-models", features = ["serde"] }
 btmesh-macro = { path = "../btmesh-macro" }
-embassy-time = { version = "0.1.0", default-features = false }
+embassy-time = { version = "0.1.3", default-features = false }
 embassy-sync = { version = "0.2.0", default-features = false, features = [
   "nightly",
 ] }

--- a/btmesh-driver/Cargo.toml
+++ b/btmesh-driver/Cargo.toml
@@ -13,7 +13,7 @@ btmesh-device = { path = "../btmesh-device" }
 btmesh-models = { path = "../btmesh-models", features = ["serde"] }
 btmesh-macro = { path = "../btmesh-macro" }
 embassy-time = { version = "0.1.3", default-features = false }
-embassy-sync = { version = "0.2.0", default-features = false, features = [
+embassy-sync = { version = "0.3.0", default-features = false, features = [
   "nightly",
 ] }
 critical-section = { version = "1.1.1", default-features = false, optional = true }

--- a/btmesh-driver/src/device/mod.rs
+++ b/btmesh-driver/src/device/mod.rs
@@ -38,7 +38,7 @@ impl BluetoothMeshDeviceContext for DeviceContext {
     }
 
     async fn receive(&self) -> AccessCountedHandle<'static, InboundPayload> {
-        self.inbound.recv().await
+        self.inbound.receive().await
     }
 }
 
@@ -65,7 +65,7 @@ impl BluetoothMeshElementContext for ElementContext {
     }
 
     async fn receive(&self) -> AccessCountedHandle<'static, InboundPayload> {
-        self.inbound.recv().await
+        self.inbound.receive().await
     }
 }
 
@@ -78,7 +78,7 @@ pub(crate) struct ModelContext<'m, M: Model> {
 
 impl<M: Model> BluetoothMeshModelContext<M> for ModelContext<'_, M> {
     async fn receive(&self) -> InboundModelPayload<M::Message> {
-        self.inbound.recv().await
+        self.inbound.receive().await
     }
 
     async fn send(&self, message: M::Message, meta: OutboundMetadata) -> Result<(), ()> {

--- a/btmesh-driver/src/lib.rs
+++ b/btmesh-driver/src/lib.rs
@@ -681,7 +681,7 @@ impl<'s, N: NetworkInterfaces, R: RngCore + CryptoRng, B: BackingStore> InnerDri
 
             if let Some(device_state) = device_state {
                 let receive_fut = self.network.receive(&device_state, &self.watchdog);
-                let transmit_fut = OUTBOUND.recv();
+                let transmit_fut = OUTBOUND.receive();
                 let io_fut = select(receive_fut, transmit_fut);
 
                 let beacon_fut = self.next_beacon();

--- a/btmesh-driver/src/models/configuration/composition_data.rs
+++ b/btmesh-driver/src/models/configuration/composition_data.rs
@@ -13,7 +13,7 @@ pub async fn dispatch<C: BluetoothMeshModelContext<ConfigurationServer>, B: Back
 ) -> Result<(), DriverError> {
     match message {
         CompositionDataMessage::Get(page) => {
-            if *page == 0 {
+            if *page == 0 || *page == 255 {
                 ctx.send(
                     CompositionStatus::new(0, storage.composition().as_ref().unwrap()).into(),
                     meta.reply(),

--- a/btmesh-macro/Cargo.toml
+++ b/btmesh-macro/Cargo.toml
@@ -10,7 +10,9 @@ resolver = "2"
 proc-macro = true
 
 [dependencies]
-btmesh-common = { path = "../btmesh-common", default-features = false, features = ["darling"]}
+btmesh-common = { path = "../btmesh-common", default-features = false, features = [
+  "darling",
+] }
 syn = { version = "1.0.89", features = ["derive", "full", "extra-traits"] }
 quote = "1.0.7"
 darling = "0.14.1"
@@ -21,4 +23,6 @@ prettyplease = "0.1.18"
 [dev-dependencies]
 btmesh-device = { path = "../btmesh-device" }
 btmesh-models = { path = "../btmesh-models" }
-embassy-time = { version = "0.1.0", default-features = false, features = ["std"] }
+embassy-time = { version = "0.1.3", default-features = false, features = [
+  "std",
+] }

--- a/btmesh-models/Cargo.toml
+++ b/btmesh-models/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-btmesh-common = { path = "../btmesh-common"}
-serde = { version = "1.0", default-features = false, features = [ "derive"], optional = true}
+btmesh-common = { path = "../btmesh-common" }
+serde = { version = "1.0", default-features = false, features = [
+  "derive",
+], optional = true }
 defmt = { version = "0.3", optional = true }
 micromath = { version = "2.0" }
 heapless = "0.7"
 
 [features]
 relay = []
-
-

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -71,6 +71,6 @@ low_power = ["btmesh-common/low_power"]
 
 [patch.crates-io]
 embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
-nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
-nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
+nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
+nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -70,7 +70,7 @@ friend = ["btmesh-common/friend"]
 low_power = ["btmesh-common/low_power"]
 
 [patch.crates-io]
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -35,7 +35,7 @@ embassy-nrf = { version = "0.1.0", default-features = false, features = [
   "time-driver-rtc1",
   "gpiote",
 ], optional = true }
-embassy-time = { version = "0.1.0", default-features = false }
+embassy-time = { version = "0.1.3", default-features = false }
 
 [features]
 default = ["nrf52840"]

--- a/btmesh-nrf-softdevice/Cargo.toml
+++ b/btmesh-nrf-softdevice/Cargo.toml
@@ -19,7 +19,7 @@ btmesh-device = { path = "../btmesh-device", default-features = false }
 heapless = "0.7"
 atomic-polyfill = { version = "1", default-features = false }
 rand_core = { version = "0.6.2", default-features = false }
-embassy-sync = { version = "0.2.0", default-features = false, features = [
+embassy-sync = { version = "0.3.0", default-features = false, features = [
   "nightly",
 ] }
 embassy-futures = { version = "0.1.0", default-features = false }

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -87,9 +87,9 @@ embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2
 embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
-nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
-nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
+nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
+nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 
 #nrf-softdevice = { path = "../../../../../nrf-softdevice/nrf-softdevice" }
 #nrf-softdevice-s140 = { path = "../../../../../nrf-softdevice/nrf-softdevice-s140" }

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -22,7 +22,7 @@ embassy-executor = { version = "0.1.1", default-features = false, features = [
   "nightly",
   "integrated-timers",
 ] }
-embassy-time = { version = "0.1.0", default-features = false, features = [
+embassy-time = { version = "0.1.3", default-features = false, features = [
   "defmt",
   "defmt-timestamp-uptime",
 ] }

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -14,13 +14,15 @@ resolver = "2"
 
 [dependencies]
 defmt = { version = "0.3" }
-defmt-rtt = { version = "0.3" }
+defmt-rtt = { version = "0.4" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-embassy-executor = { version = "0.1.1", default-features = false, features = [
+embassy-executor = { version = "0.3.0", default-features = false, features = [
+  "arch-cortex-m",
+  "executor-thread",
   "defmt",
-  "nightly",
   "integrated-timers",
+  "nightly",
 ] }
 embassy-time = { version = "0.1.3", default-features = false, features = [
   "defmt",

--- a/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/microbit/basic/Cargo.toml
@@ -82,11 +82,11 @@ opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -22,7 +22,7 @@ embassy-executor = { version = "0.1.1", default-features = false, features = [
   "nightly",
   "integrated-timers",
 ] }
-embassy-time = { version = "0.1.0", default-features = false, features = [
+embassy-time = { version = "0.1.3", default-features = false, features = [
   "defmt",
   "defmt-timestamp-uptime",
 ] }

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -14,13 +14,15 @@ resolver = "2"
 
 [dependencies]
 defmt = { version = "0.3" }
-defmt-rtt = { version = "0.3" }
+defmt-rtt = { version = "0.4" }
 panic-probe = { version = "0.3", features = ["print-defmt"] }
 
-embassy-executor = { version = "0.1.1", default-features = false, features = [
+embassy-executor = { version = "0.3.0", default-features = false, features = [
+  "arch-cortex-m",
+  "executor-thread",
   "defmt",
-  "nightly",
   "integrated-timers",
+  "nightly",
 ] }
 embassy-time = { version = "0.1.3", default-features = false, features = [
   "defmt",

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -82,11 +82,11 @@ opt-level = 1
 overflow-checks = false
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "65ed19aae272d6d6320554446f9187ec2ef8bf39" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
 nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }

--- a/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
+++ b/btmesh-nrf-softdevice/examples/nrf52840-dk/basic/Cargo.toml
@@ -87,6 +87,6 @@ embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2
 embassy-sync = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 embassy-time = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
 embassy-futures = { git = "https://github.com/embassy-rs/embassy.git", rev = "1f2be2dac5eeed739d2866b9b63ca06fdd84c276" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
-nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
-nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b3eabb5383ae16a7772924f5301e6a79d0a591f" }
+nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
+nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }
+nrf-softdevice-macro = { git = "https://github.com/embassy-rs/nrf-softdevice/", rev = "3b08bda268d343e100932cbf0df7e007826fa3be" }

--- a/btmesh-nrf-softdevice/src/gatt.rs
+++ b/btmesh-nrf-softdevice/src/gatt.rs
@@ -120,7 +120,7 @@ impl GattBearer<66> for SoftdeviceGattBearer {
     Self: 'm;
 
     fn receive(&self) -> Self::ReceiveFuture<'_> {
-        async move { Ok(self.inbound.recv().await) }
+        async move { Ok(self.inbound.receive().await) }
     }
 
     type TransmitFuture<'m> = impl Future<Output = Result<(), BearerError>> + 'm;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "nightly-2023-06-20"
+channel = "nightly-2023-09-30"
 components = ["rust-src", "rustfmt"]
 targets = ["thumbv7em-none-eabi", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
This PR fixes a compability issue with the Android version of nRF Mesh and bumps dependencies versions.

The Android nRF Mesh lib [requests composition data page 0xFF](https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/blob/1e71dabe7cd0a1047db4b662d2af41fb5e9e3584/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigCompositionDataGet.java#L35) instead of 0 as it is the case in the [iOS lib](https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/bf5c93aee97f6fc3b29092a3cea6e5c6b7d2b7ae/nRFMeshProvision/Layers/Foundation%20Layer/ConfigurationServerHandler.swift#L102).
`btmesh` doesn't answer anything when getting such request and thus composition data is never sent.

Bluetooth Mesh v1.0.1 spec states:
```
Composition Data Page 0 is mandatory. All other pages are optional. All Composition Data Pages not defined in this  specification are reserved for future use.
...
Note: In this specification, as only page 0 is defined, reading page 0xFF will always return page 0x00, but will in the future return larger page numbers first, before allowing the client to read page 0x00 later.
```

Bluetooth Mesh v1.1 might change this behaviour:

> Hi, it is mandatory to have composition data page 0 for all mesh nodes. However there can be additional pages. As the spec states the additional pages are optional. By sending 0xFF you will receive all the composition data pages available on the mesh node.

> The upcoming mesh specification 1.1 will add more clarity to this.

_Originally posted by @roshanrajaratnam in https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/issues/563#issuecomment-1650722642_

Hope this helps!